### PR TITLE
Feature nginx api whitelist

### DIFF
--- a/nginx/conf/locations/keycloak.conf
+++ b/nginx/conf/locations/keycloak.conf
@@ -1,10 +1,13 @@
 # Keycloka
-location /auth/realms/caritas-online-beratung/account {
+location ^~ /auth/realms/caritas-online-beratung/account {
     return 301 https://$server_name?reset=mail;
 }
-location /auth/resources {
+location ~* /auth/resources/4.4.0.final/(?<keycloak_endpoint>.*) {
+    if ($keycloak_endpoint_permission = forbidden) {
+        return 403;
+    }
     limit_req zone=by_ip_15rs burst=15 nodelay;
-    proxy_pass http://keycloak:8080/auth/resources;
+    proxy_pass http://keycloak:8080/auth/resources/4.4.0.final/admin/keycloak/$keycloak_endpoint$is_args$args;
     resolver 127.0.0.11;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -17,10 +20,10 @@ location /auth/resources {
     add_header Strict-Transport-Security "";
     add_header Content-Security-Policy "";
 }
-location /auth/admin {
+location ~* /auth/admin/(?<admin_endpoint>.*) {
     include ip-restrictions.conf;
     limit_req zone=by_ip_5rs burst=5;
-    proxy_pass http://keycloak:8080/auth/admin;
+    proxy_pass http://keycloak:8080/auth/admin/$admin_endpoint$is_args$args;
     resolver 127.0.0.11;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -33,9 +36,12 @@ location /auth/admin {
     add_header Strict-Transport-Security "";
     add_header Content-Security-Policy "";
 }
-location /auth {
+location ~* /auth/(?<keycloak_endpoint>.*) {
+    if ($keycloak_endpoint_permission = forbidden) {
+        return 403;
+    }
     limit_req zone=by_ip_5rs burst=5;
-    proxy_pass http://keycloak:8080/auth;
+    proxy_pass http://keycloak:8080/auth/$keycloak_endpoint$is_args$args;
     resolver 127.0.0.11;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/conf/locations/rocketchat.conf
+++ b/nginx/conf/locations/rocketchat.conf
@@ -1,7 +1,10 @@
 # Rocket.Chat
-location /api {
+location ~* api/v1/(?<rocketchat_endpoint>.*) {
     limit_req zone=by_ip_5rs burst=5;
-    proxy_pass http://rocketchat:3000/api;
+    if ($rocketchat_endpoint_permission = forbidden) {
+        return 403;
+    }
+    proxy_pass http://rocketchat:3000/api/v1/$rocketchat_endpoint$is_args$args;
     resolver 127.0.0.11;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -7,6 +7,8 @@ http {
                                    '"$http_referer" "$http_user_agent" "$gzip_ratio"';
     error_log /var/log/nginx/error.log error;
     access_log /var/log/nginx/access.log anonymous_log_format;
+    map_hash_max_size 5096;
+    map_hash_bucket_size 128;
     # use a combination of geo and map to whitelist internal (docker network) ip ranges for own service communication
     geo $ip_whitelist {
         default 1;
@@ -25,6 +27,43 @@ http {
         # example:
         # xxx.xxx.xxx.xxx off;
         # xxx.xxx.xxx.xxx/12 off;
+    }
+    map $rocketchat_endpoint $rocketchat_endpoint_permission {
+        default forbidden;
+        groups.create allowed;
+        groups.delete allowed;
+        groups.invite allowed;
+        groups.kick allowed;
+        groups.members allowed;
+        groups.counters allowed;
+        groups.messages allowed;
+        login allowed;
+        logout allowed;
+        users.delete allowed;
+        users.info allowed;
+        rooms.cleanHistory allowed;
+        '~^rooms\.upload\/?[\w]{0,30}$' allowed;
+        rooms.get allowed;
+        subscriptions.get allowed;
+        subscriptions.read allowed;
+        chat.postMessage allowed;
+    }
+    map $keycloak_endpoint $keycloak_endpoint_permission {
+        default forbidden;
+        realms/caritas-online-beratung/protocol/openid-connect/token allowed;
+        realms/caritas-online-beratung/protocol/openid-connect/certs allowed;
+        realms/caritas-online-beratung/protocol/openid-connect/logout allowed;
+        realms/caritas-online-beratung/users allowed;
+        realms/master/users allowed;
+        realms/master/protocol/openid-connect/auth allowed;
+        realms/master/protocol/openid-connect/login-status-iframe.html/init allowed;
+        realms/master/protocol/openid-connect/token allowed;
+        realms/master/login-actions/authenticate allowed;
+        realms/master/protocol/openid-connect/login-status-iframe.html allowed;
+        #resources
+        '~^login\/keycloak\/?.{0,100}$' allowed;
+        '~^admin\/keycloak\/?.{0,100}$' allowed;
+        js/keycloak.js allowed;
     }
     limit_req_zone $remote_addr_with_whitelist zone=by_ip_15rs:10m rate=15r/s;
     limit_req_zone $remote_addr_with_whitelist zone=by_ip_10rs:10m rate=10r/s;


### PR DESCRIPTION
Fixes #4 

added whitelist for api routes in order to block unused endpoints and prevent buffer overflow