### PR TITLE
feat: restrict rocketchat endpoints which are only used in the backend

### DIFF
--- a/nginx/conf/locations/rocketchat.conf
+++ b/nginx/conf/locations/rocketchat.conf
@@ -1,5 +1,73 @@
 # Rocket.Chat
+location = /api/v1/subscriptions.read{
+    limit_req zone=by_ip_5rs burst=5;
+    proxy_pass http://rocketchat:3000/api/v1/subscriptions.read;
+    resolver 127.0.0.11;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forward-Proto http;
+    proxy_set_header X-Nginx-Proxy true;
+    proxy_hide_header Origin;
+    proxy_hide_header Access-Control-Request-Method;
+    proxy_hide_header Control-Request-Headers;
+    proxy_hide_header Access-Control-Allow-Credentials;
+    proxy_hide_header Access-Control-Allow-Methods;
+    proxy_hide_header Access-Control-Allow-Headers;
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_redirect off;
+    client_max_body_size 5m;
+}
+location = /api/v1/login {
+    limit_req zone=by_ip_5rs burst=5;
+    proxy_pass http://rocketchat:3000/api/v1/login;
+    resolver 127.0.0.11;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forward-Proto http;
+    proxy_set_header X-Nginx-Proxy true;
+    proxy_hide_header Origin;
+    proxy_hide_header Access-Control-Request-Method;
+    proxy_hide_header Control-Request-Headers;
+    proxy_hide_header Access-Control-Allow-Credentials;
+    proxy_hide_header Access-Control-Allow-Methods;
+    proxy_hide_header Access-Control-Allow-Headers;
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_redirect off;
+    client_max_body_size 5m;
+}
+location = /api/v1/logout {
+    limit_req zone=by_ip_5rs burst=5;
+    proxy_pass http://rocketchat:3000/api/v1/logout;
+    resolver 127.0.0.11;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forward-Proto http;
+    proxy_set_header X-Nginx-Proxy true;
+    proxy_hide_header Origin;
+    proxy_hide_header Access-Control-Request-Method;
+    proxy_hide_header Control-Request-Headers;
+    proxy_hide_header Access-Control-Allow-Credentials;
+    proxy_hide_header Access-Control-Allow-Methods;
+    proxy_hide_header Access-Control-Allow-Headers;
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_redirect off;
+    client_max_body_size 5m;
+}
+
 location ~* api/v1/(?<rocketchat_endpoint>.*) {
+    include ip-restrictions.conf;
     limit_req zone=by_ip_5rs burst=5;
     if ($rocketchat_endpoint_permission = forbidden) {
         return 403;
@@ -25,6 +93,7 @@ location ~* api/v1/(?<rocketchat_endpoint>.*) {
     client_max_body_size 5m;
 }
 location /file-upload {
+    include ip-restrictions.conf;
     limit_req zone=by_ip_5rs;
     proxy_pass http://rocketchat:3000/file-upload;
     resolver 127.0.0.11;


### PR DESCRIPTION
In order to improve security, rocket chat endpoints which are only used in the backend are now be ip restricted
