### PR TITLE
fix: corrected whitelisting for rocket.chat and keycloak endpoints

### DIFF
--- a/nginx/conf/ip-restrictions.conf
+++ b/nginx/conf/ip-restrictions.conf
@@ -4,4 +4,3 @@
 # allow xxx.xxx.xxx.xxx/12
 
 deny all;
-

--- a/nginx/conf/locations/keycloak.conf
+++ b/nginx/conf/locations/keycloak.conf
@@ -1,13 +1,14 @@
-# Keycloka
+# Keycloak
+
+# Redirect for password reset process
 location ^~ /auth/realms/caritas-online-beratung/account {
     return 301 https://$server_name?reset=mail;
 }
-location ~* /auth/resources/4.4.0.final/(?<keycloak_endpoint>.*) {
-    if ($keycloak_endpoint_permission = forbidden) {
-        return 403;
-    }
-    limit_req zone=by_ip_15rs burst=15 nodelay;
-    proxy_pass http://keycloak:8080/auth/resources/4.4.0.final/admin/keycloak/$keycloak_endpoint$is_args$args;
+
+# Allowed for client (external) access
+location ~* ^/auth/realms/caritas-online-beratung/protocol/openid-connect/(token|logout) {
+    limit_req zone=by_ip_5rs burst=5;
+    proxy_pass http://keycloak:8080;
     resolver 127.0.0.11;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -20,28 +21,41 @@ location ~* /auth/resources/4.4.0.final/(?<keycloak_endpoint>.*) {
     add_header Strict-Transport-Security "";
     add_header Content-Security-Policy "";
 }
-location ~* /auth/admin/(?<admin_endpoint>.*) {
+location /auth/realms/caritas-online-beratung/login-actions/ {
+    limit_req zone=by_ip_5rs burst=5;
+    proxy_pass http://keycloak:8080/auth/realms/caritas-online-beratung/login-actions/;
+    resolver 127.0.0.11;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    # Remove the security headers, as Keycloak also sends them.
+    add_header X-Frame-Options: "";
+    add_header X-Content-Type-Options "";
+    add_header X-XSS-Protection "";
+    add_header Strict-Transport-Security "";
+    add_header Content-Security-Policy "";
+}
+location /auth/resources/4.4.0.final/login/caritas-theme/ {
+    limit_req zone=by_ip_10rs burst=10 nodelay;
+    proxy_pass http://keycloak:8080/auth/resources/4.4.0.final/login/caritas-theme/;
+    resolver 127.0.0.11;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    # Remove the security headers, as Keycloak also sends them.
+    add_header X-Frame-Options: "";
+    add_header X-Content-Type-Options "";
+    add_header X-XSS-Protection "";
+    add_header Strict-Transport-Security "";
+    add_header Content-Security-Policy "";
+}
+
+# Allowed for internal (Docker/server) access only
+location /auth {
     include ip-restrictions.conf;
-    limit_req zone=by_ip_5rs burst=5;
-    proxy_pass http://keycloak:8080/auth/admin/$admin_endpoint$is_args$args;
-    resolver 127.0.0.11;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    # Remove the security headers, as Keycloak also sends them.
-    add_header X-Frame-Options: "";
-    add_header X-Content-Type-Options "";
-    add_header X-XSS-Protection "";
-    add_header Strict-Transport-Security "";
-    add_header Content-Security-Policy "";
-}
-location ~* /auth/(?<keycloak_endpoint>.*) {
-    if ($keycloak_endpoint_permission = forbidden) {
-        return 403;
-    }
-    limit_req zone=by_ip_5rs burst=5;
-    proxy_pass http://keycloak:8080/auth/$keycloak_endpoint$is_args$args;
+    proxy_pass http://keycloak:8080/auth;
     resolver 127.0.0.11;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/conf/locations/keycloak.conf
+++ b/nginx/conf/locations/keycloak.conf
@@ -6,7 +6,7 @@ location ^~ /auth/realms/caritas-online-beratung/account {
 }
 
 # Allowed for client (external) access
-location ~* ^/auth/realms/caritas-online-beratung/protocol/openid-connect/(token|logout) {
+location ~ ^/auth/realms/caritas-online-beratung/protocol/openid-connect/(token|logout) {
     limit_req zone=by_ip_5rs burst=5;
     proxy_pass http://keycloak:8080;
     resolver 127.0.0.11;

--- a/nginx/conf/locations/rocketchat.conf
+++ b/nginx/conf/locations/rocketchat.conf
@@ -1,7 +1,8 @@
 # Rocket.Chat
-location = /api/v1/subscriptions.read{
+# Allowed for client (external) access
+location ~ ^/api/v1/(login|logout|subscriptions.read) {
     limit_req zone=by_ip_5rs burst=5;
-    proxy_pass http://rocketchat:3000/api/v1/subscriptions.read;
+    proxy_pass http://rocketchat:3000;
     resolver 127.0.0.11;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
@@ -11,111 +12,9 @@ location = /api/v1/subscriptions.read{
     proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forward-Proto http;
     proxy_set_header X-Nginx-Proxy true;
-    proxy_hide_header Origin;
-    proxy_hide_header Access-Control-Request-Method;
-    proxy_hide_header Control-Request-Headers;
-    proxy_hide_header Access-Control-Allow-Credentials;
-    proxy_hide_header Access-Control-Allow-Methods;
-    proxy_hide_header Access-Control-Allow-Headers;
-    proxy_hide_header Access-Control-Allow-Origin;
-    proxy_redirect off;
-    client_max_body_size 5m;
-}
-location = /api/v1/login {
-    limit_req zone=by_ip_5rs burst=5;
-    proxy_pass http://rocketchat:3000/api/v1/login;
-    resolver 127.0.0.11;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forward-Proto http;
-    proxy_set_header X-Nginx-Proxy true;
-    proxy_hide_header Origin;
-    proxy_hide_header Access-Control-Request-Method;
-    proxy_hide_header Control-Request-Headers;
-    proxy_hide_header Access-Control-Allow-Credentials;
-    proxy_hide_header Access-Control-Allow-Methods;
-    proxy_hide_header Access-Control-Allow-Headers;
-    proxy_hide_header Access-Control-Allow-Origin;
-    proxy_redirect off;
-    client_max_body_size 5m;
-}
-location = /api/v1/logout {
-    limit_req zone=by_ip_5rs burst=5;
-    proxy_pass http://rocketchat:3000/api/v1/logout;
-    resolver 127.0.0.11;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forward-Proto http;
-    proxy_set_header X-Nginx-Proxy true;
-    proxy_hide_header Origin;
-    proxy_hide_header Access-Control-Request-Method;
-    proxy_hide_header Control-Request-Headers;
-    proxy_hide_header Access-Control-Allow-Credentials;
-    proxy_hide_header Access-Control-Allow-Methods;
-    proxy_hide_header Access-Control-Allow-Headers;
-    proxy_hide_header Access-Control-Allow-Origin;
-    proxy_redirect off;
-    client_max_body_size 5m;
-}
-
-location ~* api/v1/(?<rocketchat_endpoint>.*) {
-    include ip-restrictions.conf;
-    limit_req zone=by_ip_5rs burst=5;
-    if ($rocketchat_endpoint_permission = forbidden) {
-        return 403;
-    }
-    proxy_pass http://rocketchat:3000/api/v1/$rocketchat_endpoint$is_args$args;
-    resolver 127.0.0.11;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forward-Proto http;
-    proxy_set_header X-Nginx-Proxy true;
-    proxy_hide_header Origin;
-    proxy_hide_header Access-Control-Request-Method;
-    proxy_hide_header Control-Request-Headers;
-    proxy_hide_header Access-Control-Allow-Credentials;
-    proxy_hide_header Access-Control-Allow-Methods;
-    proxy_hide_header Access-Control-Allow-Headers;
-    proxy_hide_header Access-Control-Allow-Origin;
-    proxy_redirect off;
-    client_max_body_size 5m;
-}
-location /file-upload {
-    include ip-restrictions.conf;
-    limit_req zone=by_ip_5rs;
-    proxy_pass http://rocketchat:3000/file-upload;
-    resolver 127.0.0.11;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forward-Proto http;
-    proxy_set_header X-Nginx-Proxy true;
-    proxy_hide_header Origin;
-    proxy_hide_header Access-Control-Request-Method;
-    proxy_hide_header Control-Request-Headers;
-    proxy_hide_header Access-Control-Allow-Credentials;
-    proxy_hide_header Access-Control-Allow-Methods;
-    proxy_hide_header Access-Control-Allow-Headers;
-    proxy_hide_header Access-Control-Allow-Origin;
     proxy_redirect off;
 }
 location /websocket {
-	limit_req zone=by_ip_5rs burst=5;
     proxy_pass http://rocketchat:3000/websocket;
     resolver 127.0.0.11;
     proxy_http_version 1.1;
@@ -126,12 +25,21 @@ location /websocket {
     proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forward-Proto http;
     proxy_set_header X-Nginx-Proxy true;
-    proxy_hide_header Origin;
-    proxy_hide_header Access-Control-Request-Method;
-    proxy_hide_header Control-Request-Headers;
-    proxy_hide_header Access-Control-Allow-Credentials;
-    proxy_hide_header Access-Control-Allow-Methods;
-    proxy_hide_header Access-Control-Allow-Headers;
-    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_redirect off;
+}
+
+# Allowed for internal (Docker/server) access only
+location /api {
+    include ip-restrictions.conf;
+    proxy_pass http://rocketchat:3000/api;
+    resolver 127.0.0.11;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forward-Proto http;
+    proxy_set_header X-Nginx-Proxy true;
     proxy_redirect off;
 }

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -4,6 +4,7 @@ worker_rlimit_nofile 102400;
 events {
 worker_connections 100000;
 }
+
 http {
     server_tokens off;
     log_format anonymous_log_format '$remote_user [$time_local] '
@@ -13,10 +14,11 @@ http {
     access_log /var/log/nginx/access.log anonymous_log_format;
     map_hash_max_size 5096;
     map_hash_bucket_size 128;
+
     # use a combination of geo and map to whitelist internal (docker network) ip ranges for own service communication
     geo $ip_whitelist {
         default 1;
-        # ip whitelist for secured urls
+        # ip whitelist for secured urls for rate limiting
         # example:
         # xxx.xxx.xxx.xxx off;
         # xxx.xxx.xxx.xxx/12 off;
@@ -27,48 +29,12 @@ http {
     }
     map $remote_addr $maintenance {
         default off;
-        # ip whitelist for secured urls
+        # ip whitelist for secured urls during maintenance
         # example:
         # xxx.xxx.xxx.xxx off;
         # xxx.xxx.xxx.xxx/12 off;
     }
-    map $rocketchat_endpoint $rocketchat_endpoint_permission {
-        default forbidden;
-        groups.create allowed;
-        groups.delete allowed;
-        groups.invite allowed;
-        groups.kick allowed;
-        groups.members allowed;
-        groups.counters allowed;
-        groups.messages allowed;
-        login allowed;
-        logout allowed;
-        users.delete allowed;
-        users.info allowed;
-        rooms.cleanHistory allowed;
-        '~^rooms\.upload\/?[\w]{0,30}$' allowed;
-        rooms.get allowed;
-        subscriptions.get allowed;
-        subscriptions.read allowed;
-        chat.postMessage allowed;
-    }
-    map $keycloak_endpoint $keycloak_endpoint_permission {
-        default forbidden;
-        realms/caritas-online-beratung/protocol/openid-connect/token allowed;
-        realms/caritas-online-beratung/protocol/openid-connect/certs allowed;
-        realms/caritas-online-beratung/protocol/openid-connect/logout allowed;
-        realms/caritas-online-beratung/users allowed;
-        realms/master/users allowed;
-        realms/master/protocol/openid-connect/auth allowed;
-        realms/master/protocol/openid-connect/login-status-iframe.html/init allowed;
-        realms/master/protocol/openid-connect/token allowed;
-        realms/master/login-actions/authenticate allowed;
-        realms/master/protocol/openid-connect/login-status-iframe.html allowed;
-        #resources
-        '~^login\/keycloak\/?.{0,100}$' allowed;
-        '~^admin\/keycloak\/?.{0,100}$' allowed;
-        js/keycloak.js allowed;
-    }
+
     limit_req_zone $remote_addr_with_whitelist zone=by_ip_15rs:10m rate=15r/s;
     limit_req_zone $remote_addr_with_whitelist zone=by_ip_10rs:10m rate=10r/s;
     limit_req_zone $remote_addr_with_whitelist zone=by_ip_5rs:10m rate=5r/s;
@@ -77,20 +43,23 @@ http {
     limit_conn addr 20;
     limit_req_status 429;
     limit_conn_status 429;
+
     server {
         include adminer.conf;
         include security-headers.conf;
         include ip-restrictions.conf;
         location / {
-            limit_req zone=by_ip_10rs burst=10 nodelay;
             proxy_pass http://adminer:8080;
             resolver 127.0.0.11;
+            client_max_body_size 5m;
         }
     }
+
     server {
         include server.conf;
         include security-headers.conf;
     }
+    
     server {
         include server-ssl.conf;
         include security-headers.conf;


### PR DESCRIPTION
Fixed whitelisting for Rocket.Chat and Keycloak API endpoints to enable only needed endpoints for the client.