### PR TITLE
feat: added update permission for agencyservice database user

### DIFF
--- a/MariaDB/init.sql
+++ b/MariaDB/init.sql
@@ -10,7 +10,7 @@ FLUSH PRIVILEGES;
 
 CREATE USER IF NOT EXISTS 'agencyservice'@'%' IDENTIFIED BY 'agencyservice';
 CREATE DATABASE IF NOT EXISTS agencyservice CHARACTER SET utf8 COLLATE utf8_unicode_ci;
-GRANT SELECT, INSERT ON agencyservice.* TO 'agencyservice'@'%';
+GRANT SELECT, INSERT, UPDATE ON agencyservice.* TO 'agencyservice'@'%';
 FLUSH PRIVILEGES;
 
 CREATE USER IF NOT EXISTS 'messageservice'@'%' IDENTIFIED BY 'messageservice';


### PR DESCRIPTION
Change for the Admin API to update an agency: the permissions for the agencyservice database user must be extended with the update permission